### PR TITLE
Fixed: Sitevisit cannot be approved when there is entry in attendance

### DIFF
--- a/Hrm.Application/Features/SiteVisit/Handlers/Commands/DeclineSiteVisitCommandHandler.cs
+++ b/Hrm.Application/Features/SiteVisit/Handlers/Commands/DeclineSiteVisitCommandHandler.cs
@@ -41,6 +41,11 @@ namespace Hrm.Application.Features.SiteVisit.Handlers.Commands
                 throw new NotFoundException(nameof(sitevisit), request.SiteVisitId);
             }
 
+            if(sitevisit.Status == "Approved")
+            {
+                throw new BadRequestException("Site visit is already approved");
+            }
+
             sitevisit.Status = "Declined";
             _siteVisitAtdHelper.siteVisitId  = sitevisit.SiteVisitId;
 

--- a/Hrm.Application/Helpers/SiteVisitAtdHelper.cs
+++ b/Hrm.Application/Helpers/SiteVisitAtdHelper.cs
@@ -3,6 +3,7 @@ using Hrm.Application.Contracts.Persistence;
 using Hrm.Application.DTOs.Attendance;
 using Hrm.Application.Enum;
 using Hrm.Application.Features.SiteVisit.Requests.Queries;
+using Microsoft.EntityFrameworkCore;
 using System;
 using System.Collections.Generic;
 using System.Linq;
@@ -63,6 +64,16 @@ namespace Hrm.Application.Helpers
 
             for(DateOnly curDate = from; curDate <= to; curDate = curDate.AddDays(1))
             {
+                var attendance = await _unitOfWork.Repository<Hrm.Domain.Attendance>().Where(x => x.EmpId == empId && x.AttendanceDate == curDate).FirstOrDefaultAsync();
+
+                if(attendance!=null&&(attendance.AttendanceStatusId == (int) AttendanceStatusOption.Present || attendance.AttendanceStatusId == (int) AttendanceStatusOption.Late || attendance.AttendanceStatusId == (int) AttendanceStatusOption.Absent))
+                {
+                    attendance.SiteVisitId = siteVisitId;
+                    attendance.AttendanceStatusId = (int) AttendanceStatusOption.OnSiteVisit;
+                    await _unitOfWork.Repository<Hrm.Domain.Attendance>().Update(attendance);
+                    continue;
+                }
+
                 list.Add(new CreateAttendanceDto
                 {
                     EmpId = empId,


### PR DESCRIPTION
When there is entry in attendance table, approving sitevisit update the status of the attendance to sitevisit and sitevisitId